### PR TITLE
fix: search inputs width

### DIFF
--- a/src/components/Table/SearchInput/SearchInputStyled.ts
+++ b/src/components/Table/SearchInput/SearchInputStyled.ts
@@ -33,6 +33,7 @@ const SearchInputStyled = styled.div<SearchInputStyledProps>`
       outline: none;
       font-size: 1rem;
       min-width: unset;
+      width: 100%;
 
       &:focus {
         border: none;


### PR DESCRIPTION
Missing width property, caused search inputs icons to be shifted on some mobile devices.